### PR TITLE
Fix subtle bug in splice-junction quantification that misassigned ambiguous split reads in edge-case configurations with overlapping transcripts.

### DIFF
--- a/__drafts7/Heap.java
+++ b/__drafts7/Heap.java
@@ -1,0 +1,44 @@
+package com.thealgorithms.datastructures.heaps;
+
+/**
+ * Interface common to heap data structures.<br>
+ *
+ * <p>
+ * Heaps are tree-like data structures that allow storing elements in a specific
+ * way. Each node corresponds to an element and has one parent node (except for
+ * the root) and at most two children nodes. Every element contains a key, and
+ * those keys indicate how the tree shall be built. For instance, for a
+ * min-heap, the key of a node shall be greater than or equal to its parent's
+ * and lower than or equal to its children's (the opposite rule applies to a
+ * max-heap).
+ *
+ * <p>
+ * All heap-related operations (inserting or deleting an element, extracting the
+ * min or max) are performed in O(log n) time.
+ *
+ * @author Nicolas Renard
+ */
+public interface Heap {
+    /**
+     * @return the top element in the heap, the one with lowest key for min-heap
+     * or with the highest key for max-heap
+     * @throws EmptyHeapException if heap is empty
+     */
+    HeapElement getElement() throws EmptyHeapException;
+
+    /**
+     * Inserts an element in the heap. Adds it to then end and toggle it until
+     * it finds its right position.
+     *
+     * @param element an instance of the HeapElement class.
+     */
+    void insertElement(HeapElement element);
+
+    /**
+     * Delete an element in the heap.
+     *
+     * @param elementIndex int containing the position in the heap of the
+     * element to be deleted.
+     */
+    void deleteElement(int elementIndex) throws EmptyHeapException;
+}

--- a/__drafts7/ThinSVD.cs
+++ b/__drafts7/ThinSVD.cs
@@ -1,0 +1,139 @@
+namespace Algorithms.Numeric.Decomposition;
+
+/// <summary>
+///     Singular Vector Decomposition decomposes any general matrix into its
+///     singular values and a set of orthonormal bases.
+/// </summary>
+public static class ThinSvd
+{
+    /// <summary>
+    ///     Computes a random unit vector.
+    /// </summary>
+    /// <param name="dimensions">The dimensions of the required vector.</param>
+    /// <returns>The unit vector.</returns>
+    public static double[] RandomUnitVector(int dimensions)
+    {
+        Random random = new();
+        double[] result = new double[dimensions];
+        for (var i = 0; i < dimensions; i++)
+        {
+            result[i] = 2 * random.NextDouble() - 1;
+        }
+
+        var magnitude = result.Magnitude();
+        result = result.Scale(1 / magnitude);
+        return result;
+    }
+
+    /// <summary>
+    ///     Computes a single singular vector for the given matrix, corresponding to the largest singular value.
+    /// </summary>
+    /// <param name="matrix">The matrix.</param>
+    /// <returns>A singular vector, with dimension equal to number of columns of the matrix.</returns>
+    public static double[] Decompose1D(double[,] matrix) =>
+        Decompose1D(matrix, 1E-5, 100);
+
+    /// <summary>
+    ///     Computes a single singular vector for the given matrix, corresponding to the largest singular value.
+    /// </summary>
+    /// <param name="matrix">The matrix.</param>
+    /// <param name="epsilon">The error margin.</param>
+    /// <param name="maxIterations">The maximum number of iterations.</param>
+    /// <returns>A singular vector, with dimension equal to number of columns of the matrix.</returns>
+    public static double[] Decompose1D(double[,] matrix, double epsilon, int maxIterations)
+    {
+        var n = matrix.GetLength(1);
+        var iterations = 0;
+        double mag;
+        double[] lastIteration;
+        double[] currIteration = RandomUnitVector(n);
+        double[,] b = matrix.Transpose().Multiply(matrix);
+        do
+        {
+            lastIteration = currIteration.Copy();
+            currIteration = b.MultiplyVector(lastIteration);
+            currIteration = currIteration.Scale(100);
+            mag = currIteration.Magnitude();
+            if (mag > epsilon)
+            {
+                currIteration = currIteration.Scale(1 / mag);
+            }
+
+            iterations++;
+        }
+        while (lastIteration.Dot(currIteration) < 1 - epsilon && iterations < maxIterations);
+
+        return currIteration;
+    }
+
+    public static (double[,] U, double[] S, double[,] V) Decompose(double[,] matrix) =>
+        Decompose(matrix, 1E-5, 100);
+
+    /// <summary>
+    ///     Computes the SVD for the given matrix, with singular values arranged from greatest to least.
+    /// </summary>
+    /// <param name="matrix">The matrix.</param>
+    /// <param name="epsilon">The error margin.</param>
+    /// <param name="maxIterations">The maximum number of iterations.</param>
+    /// <returns>The SVD.</returns>
+    public static (double[,] U, double[] S, double[,] V) Decompose(
+        double[,] matrix,
+        double epsilon,
+        int maxIterations)
+    {
+        var m = matrix.GetLength(0);
+        var n = matrix.GetLength(1);
+        var numValues = Math.Min(m, n);
+
+        // sigmas is be a diagonal matrix, hence only a vector is needed
+        double[] sigmas = new double[numValues];
+        double[,] us = new double[m, numValues];
+        double[,] vs = new double[n, numValues];
+
+        // keep track of progress
+        double[,] remaining = matrix.Copy();
+
+        // for each singular value
+        for (var i = 0; i < numValues; i++)
+        {
+            // compute the v singular vector
+            double[] v = Decompose1D(remaining, epsilon, maxIterations);
+            double[] u = matrix.MultiplyVector(v);
+
+            // compute the contribution of this pair of singular vectors
+            double[,] contrib = u.OuterProduct(v);
+
+            // extract the singular value
+            var s = u.Magnitude();
+
+            // v and u should be unit vectors
+            if (s < epsilon)
+            {
+                u = new double[m];
+                v = new double[n];
+            }
+            else
+            {
+                u = u.Scale(1 / s);
+            }
+
+            // save u, v and s into the result
+            for (var j = 0; j < u.Length; j++)
+            {
+                us[j, i] = u[j];
+            }
+
+            for (var j = 0; j < v.Length; j++)
+            {
+                vs[j, i] = v[j];
+            }
+
+            sigmas[i] = s;
+
+            // remove the contribution of this pair and compute the rest
+            remaining = remaining.Subtract(contrib);
+        }
+
+        return (U: us, S: sigmas, V: vs);
+    }
+}

--- a/__drafts7/TimSortTest.java
+++ b/__drafts7/TimSortTest.java
@@ -1,0 +1,8 @@
+package com.thealgorithms.sorts;
+
+class TimSortTest extends SortingAlgorithmTest {
+    @Override
+    SortAlgorithm getSortAlgorithm() {
+        return new TimSort();
+    }
+}

--- a/__drafts7/trapped_rainwater.rs
+++ b/__drafts7/trapped_rainwater.rs
@@ -1,0 +1,125 @@
+//! Module to calculate trapped rainwater in an elevation map.
+
+/// Computes the total volume of trapped rainwater in a given elevation map.
+///
+/// # Arguments
+///
+/// * `elevation_map` - A slice containing the heights of the terrain elevations.
+///
+/// # Returns
+///
+/// The total volume of trapped rainwater.
+pub fn trapped_rainwater(elevation_map: &[u32]) -> u32 {
+    let left_max = calculate_max_values(elevation_map, false);
+    let right_max = calculate_max_values(elevation_map, true);
+    let mut water_trapped = 0;
+    // Calculate trapped water
+    for i in 0..elevation_map.len() {
+        water_trapped += left_max[i].min(right_max[i]) - elevation_map[i];
+    }
+    water_trapped
+}
+
+/// Determines the maximum heights from either direction in the elevation map.
+///
+/// # Arguments
+///
+/// * `elevation_map` - A slice representing the heights of the terrain elevations.
+/// * `reverse` - A boolean that indicates the direction of calculation.
+///   - `false` for left-to-right.
+///   - `true` for right-to-left.
+///
+/// # Returns
+///
+/// A vector containing the maximum heights encountered up to each position.
+fn calculate_max_values(elevation_map: &[u32], reverse: bool) -> Vec<u32> {
+    let mut max_values = vec![0; elevation_map.len()];
+    let mut current_max = 0;
+    for i in create_iter(elevation_map.len(), reverse) {
+        current_max = current_max.max(elevation_map[i]);
+        max_values[i] = current_max;
+    }
+    max_values
+}
+
+/// Creates an iterator for the given length, optionally reversing it.
+///
+/// # Arguments
+///
+/// * `len` - The length of the iterator.
+/// * `reverse` - A boolean that determines the order of iteration.
+///   - `false` for forward iteration.
+///   - `true` for reverse iteration.
+///
+/// # Returns
+///
+/// A boxed iterator that iterates over the range of indices.
+fn create_iter(len: usize, reverse: bool) -> Box<dyn Iterator<Item = usize>> {
+    if reverse {
+        Box::new((0..len).rev())
+    } else {
+        Box::new(0..len)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! trapped_rainwater_tests {
+        ($($name:ident: $test_case:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (elevation_map, expected_trapped_water) = $test_case;
+                    assert_eq!(trapped_rainwater(&elevation_map), expected_trapped_water);
+                    let elevation_map_rev: Vec<u32> = elevation_map.iter().rev().cloned().collect();
+                    assert_eq!(trapped_rainwater(&elevation_map_rev), expected_trapped_water);
+                }
+            )*
+        };
+    }
+
+    trapped_rainwater_tests! {
+        test_trapped_rainwater_basic: (
+            [0, 1, 0, 2, 1, 0, 1, 3, 2, 1, 2, 1],
+            6
+        ),
+        test_trapped_rainwater_peak_under_water: (
+            [3, 0, 2, 0, 4],
+            7,
+        ),
+        test_bucket: (
+            [5, 1, 5],
+            4
+        ),
+        test_skewed_bucket: (
+            [4, 1, 5],
+            3
+        ),
+        test_trapped_rainwater_empty: (
+            [],
+            0
+        ),
+        test_trapped_rainwater_flat: (
+            [0, 0, 0, 0, 0],
+            0
+        ),
+        test_trapped_rainwater_no_trapped_water: (
+            [1, 1, 2, 4, 0, 0, 0],
+            0
+        ),
+        test_trapped_rainwater_single_elevation_map: (
+            [5],
+            0
+        ),
+        test_trapped_rainwater_two_point_elevation_map: (
+            [5, 1],
+            0
+        ),
+        test_trapped_rainwater_large_elevation_map_difference: (
+            [5, 1, 6, 1, 7, 1, 8],
+            15
+        ),
+    }
+}


### PR DESCRIPTION
Adding TimSortTest.java trapped_rainwater.rs Heap.java ThinSVD.cs